### PR TITLE
add $IGNORE_CONFIG to make_dotenv.sh

### DIFF
--- a/ui/make_dotenv.sh
+++ b/ui/make_dotenv.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if ("$IGNORE_CONFIG == 1"); then
+# for if we have already set up environment variables from another source, e.g. cloudflare pages
+  exit 0
+fi
 configFile="../config.yaml"
 if test -f "$configFile"; then
     address="$(grep -o "address: .*$" "$configFile" | cut -c 10-)"


### PR DESCRIPTION
for if we have already set up environment variables from another source, e.g. cloudflare pages