### PR TITLE
Add tests, remove duplication; refactor components for extensibility

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,9 @@
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "next",
 				"@sveltejs/kit": "next",
+				"@testing-library/jest-dom": "^5.16.4",
 				"@testing-library/svelte": "^3.0.3",
+				"@types/jest": "^28.1.3",
 				"@typescript-eslint/eslint-plugin": "^5.27.0",
 				"@typescript-eslint/parser": "^5.27.0",
 				"autoprefixer": "^10.4.7",
@@ -496,6 +498,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@jest/schemas": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
+			"integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
+			"dev": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.23.3"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -629,6 +643,12 @@
 			"engines": {
 				"node": ">= 8.0.0"
 			}
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
+			"integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==",
+			"dev": true
 		},
 		"node_modules/@sveltejs/adapter-auto": {
 			"version": "1.0.0-next.52",
@@ -810,6 +830,95 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@testing-library/jest-dom": {
+			"version": "5.16.4",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz",
+			"integrity": "sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.9.2",
+				"@types/testing-library__jest-dom": "^5.9.1",
+				"aria-query": "^5.0.0",
+				"chalk": "^3.0.0",
+				"css": "^3.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.5.6",
+				"lodash": "^4.17.15",
+				"redent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@testing-library/svelte": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-3.1.3.tgz",
@@ -861,6 +970,49 @@
 			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
 			"dev": true
 		},
+		"node_modules/@types/jest": {
+			"version": "28.1.3",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
+			"integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
+			"dev": true,
+			"dependencies": {
+				"jest-matcher-utils": "^28.0.0",
+				"pretty-format": "^28.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@types/jest/node_modules/pretty-format": {
+			"version": "28.1.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+			"integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^28.0.2",
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+			"dev": true
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -886,6 +1038,15 @@
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/testing-library__jest-dom": {
+			"version": "5.14.5",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
+			"integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/jest": "*"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1330,6 +1491,18 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
+		"node_modules/atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true,
+			"bin": {
+				"atob": "bin/atob.js"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
 		"node_modules/autoprefixer": {
 			"version": "10.4.7",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
@@ -1671,6 +1844,23 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+			"integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"source-map": "^0.6.1",
+				"source-map-resolve": "^0.6.0"
+			}
+		},
+		"node_modules/css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"dev": true
+		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1743,6 +1933,15 @@
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
 			"integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
 			"dev": true
+		},
+		"node_modules/decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
 		},
 		"node_modules/deep-eql": {
 			"version": "3.0.1",
@@ -1832,6 +2031,15 @@
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
 			"dev": true
+		},
+		"node_modules/diff-sequences": {
+			"version": "28.1.1",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+			"integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+			"dev": true,
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -3225,6 +3433,15 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3368,6 +3585,251 @@
 			"dependencies": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-diff": {
+			"version": "28.1.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.1.tgz",
+			"integrity": "sha512-/MUUxeR2fHbqHoMMiffe/Afm+U8U4olFRJ0hiVG2lZatPJcnGxx292ustVu7bULhjV65IYMxRdploAKLbcrsyg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"diff-sequences": "^28.1.1",
+				"jest-get-type": "^28.0.2",
+				"pretty-format": "^28.1.1"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-diff/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-diff/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-diff/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/jest-diff/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/jest-diff/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-diff/node_modules/pretty-format": {
+			"version": "28.1.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+			"integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^28.0.2",
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-diff/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-diff/node_modules/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+			"dev": true
+		},
+		"node_modules/jest-diff/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-get-type": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+			"integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils": {
+			"version": "28.1.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.1.tgz",
+			"integrity": "sha512-NPJPRWrbmR2nAJ+1nmnfcKKzSwgfaciCCrYZzVnNoxVoyusYWIjkBMNvu0RHJe7dNj4hH3uZOPZsQA+xAYWqsw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"jest-diff": "^28.1.1",
+				"jest-get-type": "^28.0.2",
+				"pretty-format": "^28.1.1"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/jest-matcher-utils/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/pretty-format": {
+			"version": "28.1.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+			"integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^28.0.2",
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+			"dev": true
+		},
+		"node_modules/jest-matcher-utils/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -3522,6 +3984,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -4296,6 +4764,19 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/redent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"dev": true,
+			"dependencies": {
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/regenerator-runtime": {
 			"version": "0.13.9",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -4573,7 +5054,6 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
-			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4585,6 +5065,17 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-resolve": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+			"integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+			"deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+			"dev": true,
+			"dependencies": {
+				"atob": "^2.1.2",
+				"decode-uri-component": "^0.2.0"
 			}
 		},
 		"node_modules/sourcemap-codec": {
@@ -5877,6 +6368,15 @@
 			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
 			"dev": true
 		},
+		"@jest/schemas": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
+			"integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
+			"dev": true,
+			"requires": {
+				"@sinclair/typebox": "^0.23.3"
+			}
+		},
 		"@jridgewell/gen-mapping": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -5982,6 +6482,12 @@
 				"estree-walker": "^2.0.1",
 				"picomatch": "^2.2.2"
 			}
+		},
+		"@sinclair/typebox": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
+			"integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==",
+			"dev": true
 		},
 		"@sveltejs/adapter-auto": {
 			"version": "1.0.0-next.52",
@@ -6119,6 +6625,74 @@
 				}
 			}
 		},
+		"@testing-library/jest-dom": {
+			"version": "5.16.4",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz",
+			"integrity": "sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.9.2",
+				"@types/testing-library__jest-dom": "^5.9.1",
+				"aria-query": "^5.0.0",
+				"chalk": "^3.0.0",
+				"css": "^3.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.5.6",
+				"lodash": "^4.17.15",
+				"redent": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"@testing-library/svelte": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-3.1.3.tgz",
@@ -6161,6 +6735,42 @@
 			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
 			"dev": true
 		},
+		"@types/jest": {
+			"version": "28.1.3",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
+			"integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
+			"dev": true,
+			"requires": {
+				"jest-matcher-utils": "^28.0.0",
+				"pretty-format": "^28.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "28.1.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+					"integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+					"dev": true,
+					"requires": {
+						"@jest/schemas": "^28.0.2",
+						"ansi-regex": "^5.0.1",
+						"ansi-styles": "^5.0.0",
+						"react-is": "^18.0.0"
+					}
+				},
+				"react-is": {
+					"version": "18.2.0",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+					"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+					"dev": true
+				}
+			}
+		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -6186,6 +6796,15 @@
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
+			}
+		},
+		"@types/testing-library__jest-dom": {
+			"version": "5.14.5",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
+			"integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
+			"dev": true,
+			"requires": {
+				"@types/jest": "*"
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
@@ -6483,6 +7102,12 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
 		"autoprefixer": {
 			"version": "10.4.7",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
@@ -6726,6 +7351,23 @@
 				"which": "^2.0.1"
 			}
 		},
+		"css": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+			"integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.4",
+				"source-map": "^0.6.1",
+				"source-map-resolve": "^0.6.0"
+			}
+		},
+		"css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"dev": true
+		},
 		"cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -6779,6 +7421,12 @@
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
 			"integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+			"dev": true
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
 			"dev": true
 		},
 		"deep-eql": {
@@ -6847,6 +7495,12 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+			"dev": true
+		},
+		"diff-sequences": {
+			"version": "28.1.1",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+			"integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
 			"dev": true
 		},
 		"dir-glob": {
@@ -7794,6 +8448,12 @@
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"dev": true
 		},
+		"indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7911,6 +8571,190 @@
 				"istanbul-lib-report": "^3.0.0"
 			}
 		},
+		"jest-diff": {
+			"version": "28.1.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.1.tgz",
+			"integrity": "sha512-/MUUxeR2fHbqHoMMiffe/Afm+U8U4olFRJ0hiVG2lZatPJcnGxx292ustVu7bULhjV65IYMxRdploAKLbcrsyg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"diff-sequences": "^28.1.1",
+				"jest-get-type": "^28.0.2",
+				"pretty-format": "^28.1.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "28.1.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+					"integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+					"dev": true,
+					"requires": {
+						"@jest/schemas": "^28.0.2",
+						"ansi-regex": "^5.0.1",
+						"ansi-styles": "^5.0.0",
+						"react-is": "^18.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+							"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+							"dev": true
+						}
+					}
+				},
+				"react-is": {
+					"version": "18.2.0",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+					"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-get-type": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+			"integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+			"dev": true
+		},
+		"jest-matcher-utils": {
+			"version": "28.1.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.1.tgz",
+			"integrity": "sha512-NPJPRWrbmR2nAJ+1nmnfcKKzSwgfaciCCrYZzVnNoxVoyusYWIjkBMNvu0RHJe7dNj4hH3uZOPZsQA+xAYWqsw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"jest-diff": "^28.1.1",
+				"jest-get-type": "^28.0.2",
+				"pretty-format": "^28.1.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "28.1.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+					"integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+					"dev": true,
+					"requires": {
+						"@jest/schemas": "^28.0.2",
+						"ansi-regex": "^5.0.1",
+						"ansi-styles": "^5.0.0",
+						"react-is": "^18.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+							"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+							"dev": true
+						}
+					}
+				},
+				"react-is": {
+					"version": "18.2.0",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+					"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8016,6 +8860,12 @@
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
+		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"lodash.merge": {
 			"version": "4.6.2",
@@ -8547,6 +9397,16 @@
 				"picomatch": "^2.2.1"
 			}
 		},
+		"redent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"dev": true,
+			"requires": {
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
+			}
+		},
 		"regenerator-runtime": {
 			"version": "0.13.9",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -8752,14 +9612,23 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true
+		},
+		"source-map-resolve": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+			"integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+			"dev": true,
+			"requires": {
+				"atob": "^2.1.2",
+				"decode-uri-component": "^0.2.0"
+			}
 		},
 		"sourcemap-codec": {
 			"version": "1.4.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,9 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
+		"@testing-library/jest-dom": "^5.16.4",
 		"@testing-library/svelte": "^3.0.3",
+		"@types/jest": "^28.1.3",
 		"@typescript-eslint/eslint-plugin": "^5.27.0",
 		"@typescript-eslint/parser": "^5.27.0",
 		"autoprefixer": "^10.4.7",

--- a/ui/src/app.test.ts
+++ b/ui/src/app.test.ts
@@ -1,9 +1,0 @@
-import {App} from "./App"
-
-describe("App", () =>{
-    test("Example test",()=>{
-
-    })
-})
-
-export {}

--- a/ui/src/components/JoinLobby.svelte
+++ b/ui/src/components/JoinLobby.svelte
@@ -4,37 +4,21 @@
     export let sendMessage : SendMessage
     import LobbyCodeInput from "./subcomponents/LobbyCodeInput.svelte";
     import UsernameInput from "./subcomponents/UsernameInput.svelte";
+    import Button from "./style/Button.svelte";
 
-    let Username = ""
+    export let Username = ""
     let LobbyCode = ""
-    $: disabled = (Username === "" || LobbyCode === "")
+    $: isButtonDisabled = (Username === "" || LobbyCode === "")
 </script>
 
-<div class="w-full bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-    <form>
-        <div class="mb-4">
-            <LobbyCodeInput ValidLobbyCode={LobbyCode} sendMessage={sendMessage}/>
-        </div>
-        <div class="mb-4">
-            <UsernameInput Username={Username}/>
-        </div>
-        <div class="flex items-center justify-between">
-            <button
-                    class="disabled:bg-gray-400 enabled:bg-blue-500 enabled:hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline min-w-[25%]"
-                    type="button"
-                    {disabled}
-                    >
-                JOIN
-                <span class="material-icons text-sm">
-                    connect_without_contact
-                </span>
-            </button>
-            <span class="text-xs">
-                By pressing JOIN you agree to our
-                <a class="inline-block align-baseline  text-blue-500 hover:text-blue-800" href="tos">
-                    Terms of Service
-                </a>
-            </span>
-        </div>
-    </form>
-</div>
+<form>
+    <div class="mb-4">
+        <UsernameInput bind:Username={Username}/>
+    </div>
+    <div class="mb-4">
+        <LobbyCodeInput ValidLobbyCode={LobbyCode} sendMessage={sendMessage}/>
+    </div>
+    <div class="flex items-center justify-center">
+        <Button disabled={isButtonDisabled} icon="connect_without_contact" text="JOIN"/>
+    </div>
+</form>

--- a/ui/src/components/style/Button.svelte
+++ b/ui/src/components/style/Button.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    export let disabled : Boolean = false
+    export let text : string = ""
+    export let icon : string | null = null
+</script>
+
+
+<button
+        class="disabled:bg-gray-400 enabled:bg-blue-500 enabled:hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline min-w-[50%]"
+        type="button"
+        {disabled}
+>
+    {text}
+    {#if icon != null}
+        <span class="material-icons text-sm">
+            {icon}
+        </span>
+    {/if}
+</button>

--- a/ui/src/components/style/Card.svelte
+++ b/ui/src/components/style/Card.svelte
@@ -1,0 +1,3 @@
+<div class="w-full bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+    <slot/>
+</div>

--- a/ui/src/components/style/Input.svelte
+++ b/ui/src/components/style/Input.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+    export let ID : string = ""
+    export let Label : string = ""
+    export let Value : string = ""
+    export let OnInput : (event : InputEvent) => void | null = null
+    export let HelperText : string | null = null
+    export let List : string | null = null
+    export let Style : string | null = null
+</script>
+
+<label class="block text-gray-700 text-sm font-bold mb-2" for={ID}>
+    {Label}
+</label>
+
+<style>
+    .invalid{
+        border-color: red;
+        color: red;
+    }
+    .valid{
+        border-color: green;
+        color: green;
+    }
+</style>
+
+<div class="shadow  border rounded w-full {Style}  leading-tight  focus:shadow-outline relative">
+    <input
+            class="appearance-none focus:outline-none bg-transparent py-2 px-3 w-full h-full text-gray-700"
+            placeholder={Label.toUpperCase()}
+            bind:value={Value}
+            on:input={OnInput}
+            id={ID}
+            list={List}
+    />
+    {#if List != null}
+    <datalist id={List}>
+        <slot/>
+    </datalist>
+    {/if}
+    {#if HelperText != null}
+    <p class="text-xs italic text-right absolute bottom-0 right-1 select-none pointer-events-none" title="helper text">{HelperText}</p>
+    {/if}
+</div>

--- a/ui/src/components/subcomponents/LobbyCodeInput.svelte
+++ b/ui/src/components/subcomponents/LobbyCodeInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import {type SendMessage} from "../../scripts/WebSocket";
     import {onMount} from "svelte";
+    import Input from "../style/Input.svelte";
     export let sendMessage : SendMessage
 
     export let ValidLobbyCode : string
@@ -10,9 +11,8 @@
     let LobbyInputClass=""
     let QueriedLobbyCode=""
 
-    const lobbyCodeInput = e => {
+    function lobbyCodeInput(e) {
         LobbyCode = NumbersOnly(e.target.value).substring(0,6)
-
         if(LobbyCode.length == 6 && LobbyCode != QueriedLobbyCode){
             sendMessage("GetLobbyDataExternal",{code:LobbyCode})
             QueriedLobbyCode = LobbyCode
@@ -35,9 +35,12 @@
 
     function onLobbyFound(e:Event){
         let msg = (e as CustomEvent).detail
-        LobbyHelperText = msg["status"]
-        LobbyInputClass="valid"
-        ValidLobbyCode = LobbyCode
+        let lobbyCode = msg["lobby"]
+        if(lobbyCode == QueriedLobbyCode){
+            LobbyHelperText = msg["status"]
+            LobbyInputClass="valid"
+            ValidLobbyCode = QueriedLobbyCode
+        }
     }
 
 
@@ -56,32 +59,7 @@
             document.removeEventListener("LobbyNotFound",onLobbyNotFound)
         }
     })
+
 </script>
 
-
-<style>
-    .invalid{
-        border-color: red;
-        color: red;
-    }
-    .valid{
-        border-color: green;
-        color: green;
-    }
-</style>
-
-<label class="block text-gray-700 text-sm font-bold mb-2" for="lobbycode">
-    Lobby Code
-</label>
-<div class="shadow  border rounded w-full {LobbyInputClass}  leading-tight  focus:shadow-outline relative">
-    <input
-            required
-            class="appearance-none focus:outline-none bg-transparent py-2 px-3 w-full h-full text-gray-700"
-            id="lobbycode"
-            placeholder="LOBBY CODE"
-            type="tel"
-            bind:value={LobbyCode}
-            on:input={lobbyCodeInput}
-    />
-    <p class="text-xs italic text-right absolute bottom-0 right-1 select-none pointer-events-none">{LobbyHelperText}</p>
-</div>
+<Input Label="Lobby Code" ID="lobbycode" bind:Value={LobbyCode} OnInput={lobbyCodeInput} HelperText={LobbyHelperText} bind:Style={LobbyInputClass}/>

--- a/ui/src/components/subcomponents/LobbyCodeInput.test.ts
+++ b/ui/src/components/subcomponents/LobbyCodeInput.test.ts
@@ -1,15 +1,95 @@
-import { beforeEach, test, expect } from "vitest"
-import { cleanup, render } from "@testing-library/svelte"
+import {describe,it} from "vitest";
+import {cleanup, render, getByLabelText, fireEvent, getByTitle} from "@testing-library/svelte"
+import type {SendMessage} from "src/scripts/WebSocket"
+
 
 import LobbyCodeInput from "./LobbyCodeInput.svelte"
+import {MockSendMessage} from "../../setupTests";
 
-beforeEach(cleanup)
-
-test("Can Render", () => {
-    render(LobbyCodeInput)
+let lastMessageSent : any
+const sendMessage : SendMessage = ((header,body)=>{
+    lastMessageSent = {Header:header,Body:body}
 })
 
-test("labeled as Lobby Code", () => {
-    const { getByText } = render(LobbyCodeInput)
-    expect(getByText("Lobby Code")).toBeDefined()
+function getFreshContainer() : HTMLElement{
+    cleanup()
+    lastMessageSent = undefined
+    const {container} = render(LobbyCodeInput,{ValidLobbyCode:"",sendMessage:sendMessage})
+    return container
+}
+
+function getLobbyCodeInputElement() : HTMLInputElement{
+    let container = getFreshContainer()
+    return getByLabelText(container,"Lobby Code") as HTMLInputElement
+}
+
+function getLobbyCodeHelperText() : HTMLElement {
+    let container = getFreshContainer()
+    return getByTitle(container,"helper text")
+}
+
+describe("Lobby Code Input",()=>{
+
+    describe("Lobby Code Input Behaviour", ()=>{
+        it("Renders",()=>{
+            let lobbyCodeInput = getLobbyCodeInputElement()
+            expect(lobbyCodeInput).toBeDefined()
+        })
+        it("Has a placeholder value of LOBBY CODE",()=>{
+            let lobbyCodeInput = getLobbyCodeInputElement()
+            expect(lobbyCodeInput.placeholder).toBe("LOBBY CODE")
+        })
+
+        it("Is empty without user input",()=>{
+            let lobbyCodeInput = getLobbyCodeInputElement()
+            expect(lobbyCodeInput).toHaveTextContent('')
+            expect(lastMessageSent).not.toBeDefined()
+        })
+
+        it("Does not accept non numeric inputs",async ()=>{
+            let lobbyCodeInput = getLobbyCodeInputElement()
+            await fireEvent.input(lobbyCodeInput, { target: { value: "h3ll0 w0r1d" } });
+            expect(lobbyCodeInput.value).toBe("3001");
+        })
+
+        it("Has a maximum input of 6 digits",async ()=>{
+            let lobbyCodeInput = getLobbyCodeInputElement()
+            await fireEvent.input(lobbyCodeInput, { target: { value: "1234567890" } });
+            expect(lobbyCodeInput.value.length).toBe(6);
+        })
+
+        it("Will send a message upon receiving a valid 6 digit code",async ()=>{
+            let lobbyCodeInput = getLobbyCodeInputElement()
+            await fireEvent.input(lobbyCodeInput, { target: { value: "123456" } });
+            expect(lastMessageSent.Body["code"]).toBe("123456")
+        })
+    })
+
+    describe("Lobby Status Helper Text",()=>{
+        it("Exists",()=>{
+            let helperText = getLobbyCodeHelperText()
+            expect(helperText).toBeDefined()
+        })
+        it("Contains nothing to begin with",()=>{
+            let helperText = getLobbyCodeHelperText()
+            expect(helperText).toHaveTextContent('')
+        })
+        it("Gives Error when Invalid Lobby",async ()=>{
+            let container = getFreshContainer()
+            await MockSendMessage("LobbyNotFound")
+            let helperText = getByTitle(container,"helper text")
+            expect(helperText).toHaveTextContent('Lobby Not Found!')
+        })
+
+        it("Displays status when Valid Lobby",async ()=>{
+            let container = getFreshContainer()
+            let lobbyCode = "123456"
+            let lobbyCodeInput = getByLabelText(container,"Lobby Code") as HTMLInputElement
+            await fireEvent.input(lobbyCodeInput, { target: { value: lobbyCode } });
+            let status = "hello, world!"
+            await MockSendMessage("LobbyFound",{lobby:lobbyCode,status:status})
+            let helperText = getByTitle(container,"helper text")
+            expect(helperText).toHaveTextContent(status)
+        })
+    })
 })

--- a/ui/src/components/subcomponents/UsernameInput.svelte
+++ b/ui/src/components/subcomponents/UsernameInput.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
+    import Input from "../style/Input.svelte";
+
     export let Username : string
 
     const usernameInput = e => {
+        console.log("hello")
         Username = e.target.value.substring(0,10).toUpperCase()
     }
 </script>
 
-<label class="block text-gray-700 text-sm font-bold mb-2" for="username">
-    Your Name
-</label>
-<input
-        required
-        class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
-        id="username"
-        placeholder="YOUR NAME"
-        bind:value={Username}
-        on:input={usernameInput}
-/>
+<Input Label="Your Name" ID="username" bind:Value={Username} OnInput={usernameInput}/>

--- a/ui/src/components/subcomponents/UsernameInput.test.ts
+++ b/ui/src/components/subcomponents/UsernameInput.test.ts
@@ -1,0 +1,22 @@
+import {describe,it} from "vitest";
+import {cleanup, render, getByLabelText, fireEvent, getByTitle} from "@testing-library/svelte"
+
+import UsernameInput from "./UsernameInput.svelte"
+
+function getFreshUserNameInput() : HTMLInputElement{
+    cleanup()
+    const {container} = render(UsernameInput)
+    return  getByLabelText(container,"Your Name") as HTMLInputElement
+}
+
+describe("Username Input",()=>{
+    it("Renders",()=>{
+        let usernameInput = getFreshUserNameInput()
+        expect(usernameInput).toBeDefined()
+    })
+    it("Has a Max Length of 10",async ()=>{
+        let usernameInput = getFreshUserNameInput()
+        await fireEvent.input(usernameInput, { target: { value: "abcdefghijklmnopqrstuvwxyz" } });
+        expect(usernameInput.value.length).toBe(10)
+    })
+})

--- a/ui/src/routes/index.svelte
+++ b/ui/src/routes/index.svelte
@@ -5,15 +5,20 @@
     import JoinLobby from "../components/JoinLobby.svelte"
     import {onMount} from "svelte";
     import {BuildWebSocket,type SendMessage} from "../scripts/WebSocket"
+    import Card from "../components/style/Card.svelte";
     let sendMessage : SendMessage = null
     onMount(()=>{
         sendMessage = BuildWebSocket()
     })
+    let Username = ""
 </script>
 
 <Header/>
 
 <div class="min-w-fit max-w-[95%] w-[30rem] mx-auto">
-    <JoinLobby sendMessage={sendMessage}/>
+    <Card>
+        <JoinLobby sendMessage={sendMessage} bind:Username={Username}/>
+    </Card>
 </div>
+
 <Footer/>

--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom/extend-expect'
+import {act} from "@testing-library/svelte";
+
+export async function MockSendMessage(header:string, body?:any){
+    let invalidLobbyEvent = new CustomEvent(header,
+        {bubbles:true,
+            cancelable:false,
+            composed:true,
+            detail:body
+        })
+    await act(()=>{
+        document.dispatchEvent(invalidLobbyEvent
+        )})
+}

--- a/ui/svelte.config.js
+++ b/ui/svelte.config.js
@@ -15,6 +15,8 @@ const config = {
 		vite: {
 			test: {
 				environment: "jsdom",
+				globals: true, // required or setupTests will say expect is undefined -- however, discouraged
+				setupFiles: "src/setupTests.ts"
 			},
 		},
 	}


### PR DESCRIPTION
Switches fully to vitest, and embraces it using TDD for LobbyCodeInput.svelte
Removes superfluous app.test.ts
Refactors duplication to create  Button.svelte, Card.svelte & Input.svelte, standardizing and following DRY principles

did a little more in this commit than I would have liked (sorry UNIX philosophy) , got carried away