### PR TITLE
Refactor Session ID handshake

### DIFF
--- a/app/server/user/factory/builder/builder.go
+++ b/app/server/user/factory/builder/builder.go
@@ -34,13 +34,7 @@ func (b builder) make(c connection.Connection) *user {
 	return usr
 }
 
-func (b builder) Build(connection connection.Connection) {
-	sID, err := connection.Read()
-	if err != nil {
-		connection.Close()
-		return
-	}
-	sessionID := string(sID)
+func (b builder) Build(connection connection.Connection, sessionID string) {
 	if sessionID != "" {
 		newConn, ok := b.sessionIDs[sessionID]
 		if ok {

--- a/app/server/user/factory/builder/builder_test.go
+++ b/app/server/user/factory/builder/builder_test.go
@@ -2,7 +2,6 @@ package builder
 
 import (
 	"encoding/json"
-	"errors"
 	"simul-app/server/message"
 	"simul-app/server/user/connection"
 	"testing"
@@ -17,18 +16,9 @@ func TestBuilderGivesNewSessionID(t *testing.T) {
 		msgIn:      []byte(""),
 		msgOut:     msgOut,
 		gotChannel: gotChannel,
-	})
+	}, "")
 	<-gotChannel
 	<-msgOut
-}
-
-func TestBuilderClosesConnectionIfReadError(t *testing.T) {
-	testBuilder := New(nil)
-	closedSignal := make(chan bool)
-	go testBuilder.Build(mockConnection{err: errors.New("read error"), closedSignal: closedSignal})
-	if closed := <-closedSignal; closed != true {
-		t.Fail()
-	}
 }
 
 func TestBuilderPassesOnConnectionIfHasSessionID(t *testing.T) {
@@ -37,6 +27,6 @@ func TestBuilderPassesOnConnectionIfHasSessionID(t *testing.T) {
 	sessionID := "hello, world!"
 	sessionIDs[sessionID] = newConnection
 	testBuilder := builder{sessionIDs: sessionIDs}
-	go testBuilder.Build(mockConnection{msgIn: []byte(sessionID)})
+	go testBuilder.Build(mockConnection{}, sessionID)
 	<-newConnection
 }

--- a/app/server/user/factory/factory.go
+++ b/app/server/user/factory/factory.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"log"
 	"net/http"
 	"simul-app/server/user"
 	"simul-app/server/user/connection"
@@ -16,7 +17,13 @@ func (f factory) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	go f.builder.Build(conn)
+	sessionIDCookie, cookieError := r.Cookie("session_id")
+	sessionID := ""
+	if cookieError == nil {
+		sessionID = sessionIDCookie.Value
+		log.Println("session reconnected: ", sessionID)
+	}
+	go f.builder.Build(conn, sessionID)
 }
 
 func New(connectionFactory connection.Factory, builder user.Builder) http.Handler {

--- a/app/server/user/factory/factory.go
+++ b/app/server/user/factory/factory.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"simul-app/server/user"
 	"simul-app/server/user/connection"
+	"strings"
 )
 
 type factory struct {
@@ -21,7 +22,9 @@ func (f factory) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sessionID := ""
 	if cookieError == nil {
 		sessionID = sessionIDCookie.Value
-		log.Println("session reconnected: ", sessionID)
+		escapedSessionID := strings.Replace(sessionID, "\n", "", -1)
+		escapedSessionID = strings.Replace(escapedSessionID, "\r", "", -1)
+		log.Println("session reconnected: ", escapedSessionID)
 	}
 	go f.builder.Build(conn, sessionID)
 }

--- a/app/server/user/factory/factory_test.go
+++ b/app/server/user/factory/factory_test.go
@@ -17,7 +17,7 @@ func TestFactoryBuildsIfNoError(t *testing.T) {
 	noError := mockConnection{false}
 	built := make(chan bool)
 	userFactory := New(noError, mockBuilder{built})
-	userFactory.ServeHTTP(nil, nil)
+	userFactory.ServeHTTP(nil, &http.Request{})
 	<-built
 }
 
@@ -36,13 +36,13 @@ type mockBuilder struct {
 	built chan bool
 }
 
-func (m mockBuilder) Build(_ connection.Connection) {
+func (m mockBuilder) Build(_ connection.Connection, _ string) {
 	m.built <- true
 }
 
 type builderThatPanicsIfAskedToBuild struct {
 }
 
-func (m builderThatPanicsIfAskedToBuild) Build(_ connection.Connection) {
+func (m builderThatPanicsIfAskedToBuild) Build(_ connection.Connection, _ string) {
 	panic("asked to build!")
 }

--- a/app/server/user/interfaces.go
+++ b/app/server/user/interfaces.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Builder interface {
-	Build(connection connection.Connection)
+	Build(connection connection.Connection, sessionID string)
 }
 
 type IDGenerator interface {

--- a/ui/src/props/WebSockets.ts
+++ b/ui/src/props/WebSockets.ts
@@ -1,5 +1,5 @@
 import useWebSocket, {ReadyState} from "react-use-websocket";
-import {getCookie, setCookie} from "typescript-cookie";
+import {setCookie} from "typescript-cookie";
 import {useCallback} from "react";
 
 type message = {Header:string,Body?:any}
@@ -21,11 +21,7 @@ export const useConnection = () : [ConnectionState,SendMessage] => {
         `${REACT_APP_WEBSOCKET_ADDRESS}/`,
         {
             onOpen : (e:Event) => {
-                let ws = e.currentTarget as WebSocket
-                console.log("sending ID!")
-                let sessionIDCookie : string | undefined = getCookie("session_id")
-                let sessionID: string = sessionIDCookie ? sessionIDCookie : ""
-                ws.send(sessionID)
+                console.log("connected :",e)
             },
             onMessage: (message: MessageEvent) => {
                 let parsed = JSON.parse(message.data)


### PR DESCRIPTION
Websockets now take sessionID from websocket request header instead of from the first message