### PR TITLE
attempts to reduce render blocking

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -1,3 +1,32 @@
+/* Tailwind */
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Material Icons */
+
+
+/* fallback */
+@font-face {
+    font-family: 'Material Icons';
+    font-style: normal;
+    font-weight: 400;
+    src: url(https://fonts.gstatic.com/s/materialicons/v134/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2) format('woff2');
+}
+
+.material-icons {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -moz-font-feature-settings: 'liga';
+    -moz-osx-font-smoothing: grayscale;
+}

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -1,20 +1,4 @@
 <!DOCTYPE html>
-<!-- Material Icons -->
-<link
-		rel="stylesheet"
-		href="https://fonts.googleapis.com/icon?family=Material+Icons"
-/>
-<!-- Roboto -->
-<link
-		rel="stylesheet"
-		href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700"
-/>
-<!-- Roboto Mono -->
-<link
-		rel="stylesheet"
-		href="https://fonts.googleapis.com/css?family=Roboto+Mono"
-/>
-
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />


### PR DESCRIPTION
raises google pagespeed results on mobile from 86 to 90, and on desktop from 99 to 100

todo, at a later point: probably replace material icons with the individual svgs as/when needed; the entire icon set is 126kb, double the size of the page.