### PR TITLE
Fixes eslint config:

### DIFF
--- a/webclient/.eslintrc.cjs
+++ b/webclient/.eslintrc.cjs
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
     root: true,
     parser: "@typescript-eslint/parser",
     extends: [


### PR DESCRIPTION
"Revert to use ESM eslint config files"

SvelteKit create upstream had a bug when the project was created; this is the fix